### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,6 +9,7 @@
     "library_type": "OTHER",
     "repo": "googleapis/python-audit-log",
     "distribution_name": "google-cloud-audit-log",
-    "api_id": ""
-  }
-  
+    "api_id": "",
+    "default_version": "",
+    "codeowner_team": ""
+}


### PR DESCRIPTION
Both `default_version` and `codeowner_team` have empty strings for this repo. By default the code owner will be googleapis/yoshi-python. This change is needed for the following synthtool PRs:

https://github.com/googleapis/synthtool/pull/1201
https://github.com/googleapis/synthtool/pull/1114